### PR TITLE
Update go-whisper from 1.1.1 to 1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/appleboy/go-whisper:1.1.1
+FROM ghcr.io/appleboy/go-whisper:1.3.0
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
for 1.1.1, download video from youtube will cause `no formats found` due to mimetype

https://github.com/appleboy/go-whisper/blob/9ebf0ff9bb0c7ddb37286e3489638ee2897e5595/youtube/youtube.go#L89-L98

```go
mimetype := "video/3gpp"
outputQuality := ""


formats := e.video.Formats
if mimetype != "" {
        formats = formats.Type(mimetype)
}
if len(formats) == 0 {
        return "", errors.New("no formats found")
}
```

<img width="606" alt="image" src="https://github.com/appleboy/whisper-action/assets/44502608/f0752bda-3376-4327-925a-10b2999888ba">

it has been fixed in https://github.com/appleboy/go-whisper/commit/a0cab0d0c352de1882924f33e67b1dc85b2f7ba4
